### PR TITLE
enable basic apache modules by default

### DIFF
--- a/src/7.3/apache/Dockerfile
+++ b/src/7.3/apache/Dockerfile
@@ -1,7 +1,10 @@
 FROM jrobinsonc/php:7.3-apache
 
-RUN apt-get update; \
+RUN set -eux; \
+    apt-get update; \
     curl -sL https://deb.nodesource.com/setup_12.x | bash -; \
     apt-get install -y nodejs mariadb-client; \
     docker-php-ext-install bcmath pdo_mysql; \
     rm -rf /var/lib/apt/lists/*;
+
+RUN a2enmod rewrite expires headers


### PR DESCRIPTION
Apache modules: rewrite expires headers